### PR TITLE
Drop indexed column when is not needed

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
@@ -40,18 +40,4 @@ trait RevisionFactory[DataSchema] {
       schema: DataSchema,
       options: Map[String, String]): Revision
 
-  /**
-   * Create a new revision with given parameters from an old revision
-   * @param qtableID the table identifier
-   * @param schema the schema
-   * @param options the options
-   * @param oldRevision the old revision
-   * @return
-   */
-  def createNextRevision(
-      qtableID: QTableID,
-      schema: DataSchema,
-      options: Map[String, String],
-      oldRevision: RevisionID): Revision
-
 }

--- a/core/src/main/scala/io/qbeast/core/transform/HashTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HashTransformer.scala
@@ -16,10 +16,10 @@ case class HashTransformer(
 
   override def stats: ColumnStats = NoColumnStats
 
-  override def makeTransformation(row: String => Any): Transformation = {
+  override def maybeMakeTransformation(row: String => Any): Option[Transformation] = {
     optionalNullValue match {
-      case Some(nullValue) => HashTransformation(nullValue)
-      case None => HashTransformation()
+      case Some(nullValue) => Some(HashTransformation(nullValue))
+      case None => Some(HashTransformation())
     }
   }
 

--- a/core/src/main/scala/io/qbeast/core/transform/HashTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HashTransformer.scala
@@ -16,10 +16,12 @@ case class HashTransformer(
 
   override def stats: ColumnStats = NoColumnStats
 
-  override def maybeMakeTransformation(row: String => Any): Option[Transformation] = {
+  override def isIdentityTransformation(row: String => Any): Boolean = false
+
+  override def makeTransformation(row: String => Any): Transformation = {
     optionalNullValue match {
-      case Some(nullValue) => Some(HashTransformation(nullValue))
-      case None => Some(HashTransformation())
+      case Some(nullValue) => HashTransformation(nullValue)
+      case None => HashTransformation()
     }
   }
 

--- a/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
@@ -133,11 +133,18 @@ trait Transformer extends Serializable {
   def stats: ColumnStats
 
   /**
+   * Returns wether the transformation is identity or not
+   * @param row the values
+   * @return the transformation
+   */
+  def isIdentityTransformation(row: String => Any): Boolean
+
+  /**
    * Returns the Transformation given a row representation of the values
    * @param row the values
    * @return the transformation
    */
-  def maybeMakeTransformation(row: String => Any): Option[Transformation]
+  def makeTransformation(row: String => Any): Transformation
 
   /**
    * Returns the new Transformation if the space has changed
@@ -149,15 +156,15 @@ trait Transformer extends Serializable {
   def maybeUpdateTransformation(
       currentTransformation: Transformation,
       row: Map[String, Any]): Option[Transformation] = {
-    val possibleDataTransformation = maybeMakeTransformation(row)
-    possibleDataTransformation match {
-      case Some(newDataTransformation) =>
-        if (currentTransformation.isSupersededBy(newDataTransformation)) {
-          Some(currentTransformation.merge(newDataTransformation))
-        } else {
-          None
-        }
-      case None => None
+    if (isIdentityTransformation(row.get)) {
+      None
+    } else {
+      val newDataTransformation = makeTransformation(row.get)
+      if (currentTransformation.isSupersededBy(newDataTransformation)) {
+        Some(currentTransformation.merge(newDataTransformation))
+      } else {
+        None
+      }
     }
   }
 

--- a/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
@@ -156,15 +156,12 @@ trait Transformer extends Serializable {
   def maybeUpdateTransformation(
       currentTransformation: Transformation,
       row: Map[String, Any]): Option[Transformation] = {
-    if (isIdentityTransformation(row.get)) {
-      None
+    if (isIdentityTransformation(row)) return None
+    val newDataTransformation = makeTransformation(row)
+    if (currentTransformation.isSupersededBy(newDataTransformation)) {
+      Some(currentTransformation.merge(newDataTransformation))
     } else {
-      val newDataTransformation = makeTransformation(row.get)
-      if (currentTransformation.isSupersededBy(newDataTransformation)) {
-        Some(currentTransformation.merge(newDataTransformation))
-      } else {
-        None
-      }
+      None
     }
   }
 

--- a/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
@@ -137,7 +137,7 @@ trait Transformer extends Serializable {
    * @param row the values
    * @return the transformation
    */
-  def makeTransformation(row: String => Any): Transformation
+  def maybeMakeTransformation(row: String => Any): Option[Transformation]
 
   /**
    * Returns the new Transformation if the space has changed
@@ -149,11 +149,15 @@ trait Transformer extends Serializable {
   def maybeUpdateTransformation(
       currentTransformation: Transformation,
       row: Map[String, Any]): Option[Transformation] = {
-    val newDataTransformation = makeTransformation(row)
-    if (currentTransformation.isSupersededBy(newDataTransformation)) {
-      Some(currentTransformation.merge(newDataTransformation))
-    } else {
-      None
+    val possibleDataTransformation = maybeMakeTransformation(row)
+    possibleDataTransformation match {
+      case Some(newDataTransformation) =>
+        if (currentTransformation.isSupersededBy(newDataTransformation)) {
+          Some(currentTransformation.merge(newDataTransformation))
+        } else {
+          None
+        }
+      case None => None
     }
   }
 

--- a/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
@@ -28,14 +28,15 @@ class TransformerTest extends AnyFlatSpec with Matchers {
 
   }
 
-  it should "makeTransformation" in {
+  it should "maybeMakeTransformation" in {
     val columnName = "a"
     val dataType = IntegerDataType
     val transformer = Transformer("linear", columnName, "1", dataType)
 
     val transformation = Map("a_min" -> 0, "a_max" -> 2)
     transformer
-      .makeTransformation(transformation) shouldBe LinearTransformation(0, 2, 1, dataType)
+      .maybeMakeTransformation(transformation)
+      .get shouldBe LinearTransformation(0, 2, 1, dataType)
   }
 
   it should "return new transformation on maybeUpdateTransformation" in {
@@ -44,7 +45,7 @@ class TransformerTest extends AnyFlatSpec with Matchers {
     val transformer = Transformer("linear", columnName, "4", dataType)
 
     val transformation = Map("a_min" -> 0, "a_max" -> 1)
-    val currentTransformation = transformer.makeTransformation(transformation)
+    val currentTransformation = transformer.maybeMakeTransformation(transformation).get
 
     val newTransformation = Map("a_min" -> 3, "a_max" -> 8)
     transformer.maybeUpdateTransformation(currentTransformation, newTransformation) shouldBe Some(

--- a/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
@@ -35,8 +35,7 @@ class TransformerTest extends AnyFlatSpec with Matchers {
 
     val transformation = Map("a_min" -> 0, "a_max" -> 2)
     transformer
-      .maybeMakeTransformation(transformation)
-      .get shouldBe LinearTransformation(0, 2, 1, dataType)
+      .makeTransformation(transformation) shouldBe LinearTransformation(0, 2, 1, dataType)
   }
 
   it should "return new transformation on maybeUpdateTransformation" in {
@@ -45,7 +44,7 @@ class TransformerTest extends AnyFlatSpec with Matchers {
     val transformer = Transformer("linear", columnName, "4", dataType)
 
     val transformation = Map("a_min" -> 0, "a_max" -> 1)
-    val currentTransformation = transformer.maybeMakeTransformation(transformation).get
+    val currentTransformation = transformer.makeTransformation(transformation)
 
     val newTransformation = Map("a_min" -> 3, "a_max" -> 8)
     transformer.maybeUpdateTransformation(currentTransformation, newTransformation) shouldBe Some(

--- a/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.index
 
-import io.qbeast.core.model.{QDataType, QTableID, Revision, RevisionFactory, RevisionID}
+import io.qbeast.core.model.{QDataType, QTableID, Revision, RevisionFactory}
 import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.utils.SparkToQTypesUtils
 import io.qbeast.core.transform.Transformer
@@ -42,15 +42,6 @@ object SparkRevisionFactory extends RevisionFactory[StructType] {
     }.toVector
 
     Revision.firstRevision(qtableID, desiredCubeSize, transformers)
-  }
-
-  override def createNextRevision(
-      qtableID: QTableID,
-      schema: StructType,
-      options: Map[String, String],
-      oldRevisionID: RevisionID): Revision = {
-    val revision = createNewRevision(qtableID, schema, options)
-    revision.copy(revisionID = oldRevisionID + 1)
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -150,9 +150,8 @@ private[table] class IndexedTableImpl(
           latestIndexStatus
         } else {
           val oldRevisionID = latestIndexStatus.revision.revisionID
-          val newRevision = revisionBuilder
-            .createNextRevision(tableID, data.schema, parameters, oldRevisionID)
-          IndexStatus(newRevision)
+          val newRevision = revisionBuilder.createNewRevision(tableID, data.schema, parameters)
+          IndexStatus(newRevision.copy(revisionID = oldRevisionID + 1))
         }
       } else {
         IndexStatus(revisionBuilder.createNewRevision(tableID, data.schema, parameters))

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -133,9 +133,10 @@ private[table] class IndexedTableImpl(
 
   private def checkRevisionParameters(
       qbeastOptions: QbeastOptions,
-      latestRevision: Revision): Boolean = {
+      latestIndexStatus: IndexStatus): Boolean = {
     // TODO feature: columnsToIndex may change between revisions
-    latestRevision.desiredCubeSize == qbeastOptions.cubeSize
+    checkColumnsToMatchSchema(latestIndexStatus)
+    latestIndexStatus.revision.desiredCubeSize == qbeastOptions.cubeSize
 
   }
 
@@ -144,9 +145,9 @@ private[table] class IndexedTableImpl(
       parameters: Map[String, String],
       append: Boolean): BaseRelation = {
     val indexStatus =
-      if (exists) {
+      if (exists && append) {
         val latestIndexStatus = snapshot.loadLatestIndexStatus
-        if (checkRevisionParameters(QbeastOptions(parameters), latestIndexStatus.revision)) {
+        if (checkRevisionParameters(QbeastOptions(parameters), latestIndexStatus)) {
           latestIndexStatus
         } else {
           val oldRevisionID = latestIndexStatus.revision.revisionID
@@ -156,10 +157,6 @@ private[table] class IndexedTableImpl(
       } else {
         IndexStatus(revisionBuilder.createNewRevision(tableID, data.schema, parameters))
       }
-
-    if (exists && append) {
-      checkColumnsToMatchSchema(indexStatus)
-    }
 
     val relation = write(data, indexStatus, append)
     relation

--- a/src/test/scala/io/qbeast/spark/index/DoublePassOTreeDataAnalyzerTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/DoublePassOTreeDataAnalyzerTest.scala
@@ -120,7 +120,8 @@ class DoublePassOTreeDataAnalyzerTest extends QbeastIntegrationTestSpec {
     revisionChanges.get.supersededRevision shouldBe emptyRevision
     revisionChanges.get.transformationsChanges.count(_.isDefined) shouldBe columnsToIndex.length
     revisionChanges.get.desiredCubeSizeChange shouldBe None
-    revisionChanges.get.columnTransformersChanges shouldBe Vector.empty
+    revisionChanges.get.columnTransformersChanges shouldBe
+      Vector.fill(columnTransformers.size)(None)
 
     val revision = revisionChanges.get.createNewRevision
 


### PR DESCRIPTION
This PR is to understand if it makes sense to **drop** an indexed column by the user when **all the column values are the same** (null or not). 

If you can @cugni, review and give feedback to merge it with the null values support. :pray: 