### PR TITLE
Fix for SaveAsTableRule to work with Spark 3.5

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/rules/SaveAsTableRule.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/SaveAsTableRule.scala
@@ -23,11 +23,14 @@ class SaveAsTableRule(spark: SparkSession) extends Rule[LogicalPlan] with Loggin
   private def createTableSpec(
       tableSpec: TableSpecBase,
       writeOptions: Map[String, String]): TableSpec = {
-    val finalProperties = writeOptions ++ tableSpec.properties
+    val options = tableSpec match {
+      case s: TableSpec => writeOptions ++ s.options
+      case _ => writeOptions
+    }
     TableSpec(
-      properties = finalProperties,
+      properties = tableSpec.properties,
       provider = tableSpec.provider,
-      options = writeOptions,
+      options = options,
       location = tableSpec.location,
       comment = tableSpec.comment,
       serde = tableSpec.serde,

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -277,7 +277,7 @@ private[table] class IndexedTableImpl(
         val optionalColumnsToIndex = parameters.contains(COLUMNS_TO_INDEX)
         val updatedParameters = if (!optionalColumnsToIndex && !COLUMN_SELECTOR_ENABLED) {
           throw AnalysisExceptionFactory.create(
-            "Auto indexing is disabled. Pleasespecify the columns to index in a comma separated way" +
+            "Auto indexing is disabled. Please specify the columns to index in a comma separated way" +
               " as .option(columnsToIndex, ...) or enable auto indexing with spark.qbeast.index.autoIndexingEnabled=true")
         } else if (COLUMN_SELECTOR_ENABLED) {
           val columnsToIndex = autoIndexer.selectColumnsToIndex(data)


### PR DESCRIPTION
I hope to fix SaveAsTableRule for Spark 3.5. The problem which causes the QbeastSQLIntegrationTest to fail is that they on the way of transition from TableSpec.properties to TableSpec.options. Also for some reasons writeOptions are always empty and our options like colunsToIndex specified in SQL are included into TableSpec.options instead. So I changed our rule to ensure that the columnsToIndex are available for the Qbeast writing mechanism.